### PR TITLE
Fixes #43 Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ nbactions.xml
 /core/codegen/
 /web/src/main/java/assets/combined.min.js
 /web/src/main/java/assets/combined.js
+
+#OSX specific
+.DS_Store

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM java:8
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+RUN wget https://serposcope.serphacker.com/download/2.2.0/serposcope_2.3.0_all.deb -O /tmp/serposcope.deb
+RUN dpkg -i /tmp/serposcope.deb
+RUN rm /tmp/serposcope.deb
+COPY serposcope /etc/default/serposcope
+
+VOLUME /var/lib/serposcope/
+
+EXPOSE 7134
+
+CMD java -jar /usr/share/serposcope/serposcope.jar >$LOGDIR/startup.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,4 +11,4 @@ VOLUME /var/lib/serposcope/
 
 EXPOSE 7134
 
-CMD java -jar /usr/share/serposcope/serposcope.jar >$LOGDIR/startup.log
+CMD service serposcope start && tail -F /var/log/serposcope/startup.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM java:8
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-RUN wget https://serposcope.serphacker.com/download/2.2.0/serposcope_2.3.0_all.deb -O /tmp/serposcope.deb
+RUN wget https://serposcope.serphacker.com/download/2.3.0/serposcope_2.3.0_all.deb -O /tmp/serposcope.deb
 RUN dpkg -i /tmp/serposcope.deb
 RUN rm /tmp/serposcope.deb
 COPY serposcope /etc/default/serposcope

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,8 +48,6 @@ Your running Serposcope version should now be up-to-date.
 
  ```docker commit my_serposcope yourname/serposcope```
 
- test.
-
 ## TODO
 
  Enable configuration of Serposcope options through environment variables.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,55 @@
+# Serposcope docker image
+
+This folder contains the necessary files to build and run a Serposcope Docker image on any Docker-enabled environment
+
+## Build
+
+Building is done by running the following command from this directory:
+
+```docker build -t yourname/serposcope . ```
+
+If you use Docker Machine, don't forget to configure you Docker daemon accordingly.
+
+## Launching a container
+
+You can launch a container this way:
+
+```docker run -d -p 7134:7134 --name my_serposcope yourname/serposcope```
+
+You should then be able to access the tool at ```http://youServerAddress:7134```
+
+Note that you can change the host port on which you reach serposcope. For instance, if you want to use the 80 port from your host, you can do:
+
+```docker run -d -p 80:7134 --name my_serposcope yourname/serposcope```
+
+## Updating Serposcope without rebuilding the image
+
+You can easily update the Serposcope version in your container, first, access the bash prompt:
+
+``` docker exec -ti my_serposcope /bin/bash ```
+
+Then download the new deb package:
+
+```wget https://serposcope.serphacker.com/download/<replace_by_latest_version>/serposcope_<replace_by_latest_version>_all.deb```
+
+ and install it:
+
+ ```dpkg -i serposcope_<replace_by_latest_version>_all.deb```
+
+ and finally, restart the container:
+
+ ```docker restart my_serposcope```
+
+Your running Serposcope version should now be up-to-date.
+
+## Persisting the update
+
+ You can also commit the changes to the Serposcope image saved on your host (or your registry) by running:
+
+ ```docker commit my_serposcope yourname/serposcope```
+
+ test.
+
+## TODO
+
+ Enable configuration of Serposcope options through environment variables.

--- a/docker/serposcope
+++ b/docker/serposcope
@@ -1,0 +1,6 @@
+JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+LOGDIR=/var/log/serposcope
+DATADIR=/var/lib/serposcope
+CONF=/etc/serposcope.conf
+PARAMS="-Dserposcope.conf=$CONF"


### PR DESCRIPTION
This PR contains a "docker" folder with the necessary files and instructions to build and run a docker image of Serposcope. 
I needed one but could not find any, so I made it and now is the time to share with everyone. Hope it helps. 