### PR TITLE
Add 7 days option to datepicker

### DIFF
--- a/web/src/main/java/assets/js/views/admin/DebugController.js
+++ b/web/src/main/java/assets/js/views/admin/DebugController.js
@@ -16,6 +16,7 @@ serposcope.adminDebugController = function () {
             "ranges": {
                 'Last 90 days': [moment(maxDate).subtract(90, 'days'), moment(maxDate)],
                 'Last 30 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
+                'Last 7 days': [moment(maxDate).subtract(7, 'days'), moment(maxDate)],
                 'Current Month': [moment(maxDate).startOf('month'), moment(maxDate).endOf('month')],
                 'Previous Month': [moment(maxDate).subtract(1, 'month').startOf('month'), moment(maxDate).subtract(1, 'month').endOf('month')]
             },

--- a/web/src/main/java/assets/js/views/google/GoogleSearchController.js
+++ b/web/src/main/java/assets/js/views/google/GoogleSearchController.js
@@ -289,7 +289,7 @@ serposcope.googleSearchController = function () {
             var maxDate = $('#csp-vars').attr('data-max-date');
             $('#daterange-search').daterangepicker({
                 "ranges": {
-                    'Last 30 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
+                    'Last 30 days': [moment(maxDate).subtract(7, 'days'), moment(maxDate)],
                     'Last 7 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
                     'Current Month': [moment(maxDate).startOf('month'), moment(maxDate).endOf('month')],
                     'Previous Month': [moment(maxDate).subtract(1, 'month').startOf('month'), moment(maxDate).subtract(1, 'month').endOf('month')]

--- a/web/src/main/java/assets/js/views/google/GoogleSearchController.js
+++ b/web/src/main/java/assets/js/views/google/GoogleSearchController.js
@@ -290,6 +290,7 @@ serposcope.googleSearchController = function () {
             $('#daterange-search').daterangepicker({
                 "ranges": {
                     'Last 30 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
+                    'Last 7 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
                     'Current Month': [moment(maxDate).startOf('month'), moment(maxDate).endOf('month')],
                     'Previous Month': [moment(maxDate).subtract(1, 'month').startOf('month'), moment(maxDate).subtract(1, 'month').endOf('month')]
                 },

--- a/web/src/main/java/assets/js/views/google/GoogleTargetController.js
+++ b/web/src/main/java/assets/js/views/google/GoogleTargetController.js
@@ -160,7 +160,7 @@ serposcope.googleTargetController = function () {
             var maxDate = $('#csp-vars').attr('data-max-date');
             $('#daterange').daterangepicker({
                 "ranges": {
-                    'Last 7 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
+                    'Last 7 days': [moment(maxDate).subtract(7, 'days'), moment(maxDate)],
                     'Last 30 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
                     'Last 90 days': [moment(maxDate).subtract(90, 'days'), moment(maxDate)],
                     'Current Month': [moment(maxDate).startOf('month'), moment(maxDate).endOf('month')],

--- a/web/src/main/java/assets/js/views/google/GoogleTargetController.js
+++ b/web/src/main/java/assets/js/views/google/GoogleTargetController.js
@@ -160,6 +160,7 @@ serposcope.googleTargetController = function () {
             var maxDate = $('#csp-vars').attr('data-max-date');
             $('#daterange').daterangepicker({
                 "ranges": {
+                    'Last 7 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
                     'Last 30 days': [moment(maxDate).subtract(30, 'days'), moment(maxDate)],
                     'Last 90 days': [moment(maxDate).subtract(90, 'days'), moment(maxDate)],
                     'Current Month': [moment(maxDate).startOf('month'), moment(maxDate).endOf('month')],


### PR DESCRIPTION
On the website's table view the shortest date shortcut is for '30 days' and on some devices like mobile (or 11" macbook) the 30 days table is way too wide that force people to scroll to see the latest result.

Somehow the need to scroll is a little bit annoying, especially when you just want to take a quick look. (Yes, you can set a custom range, but it takes a lot of click, and people are lazy)

There is 2 ways solve this:
- Add smaller range as a shortcut
- Reverse the website's table horizontally, so the latest data shown on the leftest

Thank you for your time and attention, Serposcope is really useful!