### PR TITLE
Make replace_param() function handles "&" character correctly

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@
 conf_file="/etc/serposcope.conf"
 
 function replace_param {
-  sed -i -r -e "/^# *${1}=/ {s|^# *||;s|=.*$|=|;s|$|$(eval echo \$$2)|}" $conf_file
+  sed -i -r -e "/^# *${1}=/ {s|^# *||;s|=.*$|=|;s|$|$(eval echo \$$2 | sed 's/&/\\&/g')|}" $conf_file
 }
 
 if [ -n "$SERPOSCOPE_DB_URL" ]


### PR DESCRIPTION
I faced a problem that the `SERPOSCOPE_DB_URL` environmental variable does not work.

The `replace_param()` function in `docker/entrypoint.sh` has an issue which does not handles special character `&` correctly.

Example:
```
jdbc:mysql://HOSTNAME/DATABASE?user=USER&password=PASS&allowMultiQueries=true
will be converted to
jdbc:mysql://HOSTNAME/DATABASE?user=USERpassword=PASSallowMultiQueries=true
```

So, I fixed the issue by adding piped `sed` command which perform escaping `&` characters.