### PR TITLE
Validate proxy ip only if using BIND type

### DIFF
--- a/scraper/src/test/java/com/serphacker/serposcope/scraper/http/proxy/ProxyHelperTest.java
+++ b/scraper/src/test/java/com/serphacker/serposcope/scraper/http/proxy/ProxyHelperTest.java
@@ -34,7 +34,18 @@ public class ProxyHelperTest {
         assertEquals(1234, httpProxy.port);
         assertNull(httpProxy.username);
         assertNull(httpProxy.password);
-        
+
+        httpProxy = (HttpProxy) helper.parse("http://login:pass@localhost:1234/");
+        assertEquals("localhost", httpProxy.ip);
+        assertEquals(1234, httpProxy.port);
+        assertEquals("login", httpProxy.username);
+        assertEquals("pass", httpProxy.password);
+
+        httpProxy = (HttpProxy) helper.parse("http://localhost:1234/");
+        assertEquals("localhost", httpProxy.ip);
+        assertEquals(1234, httpProxy.port);
+        assertNull(httpProxy.username);
+        assertNull(httpProxy.password);
     }
     
     @Test
@@ -62,8 +73,31 @@ public class ProxyHelperTest {
         assertEquals("127.0.0.1", socksProxy.ip);
         assertEquals(1234, socksProxy.port);
         assertNull(socksProxy.username);
-        assertNull(socksProxy.password);        
-        
+        assertNull(socksProxy.password);
+
+        socksProxy = (SocksProxy) helper.parse("socks://login:pass@localhost:1234/");
+        assertEquals("localhost", socksProxy.ip);
+        assertEquals(1234, socksProxy.port);
+        assertEquals("login", socksProxy.username);
+        assertEquals("pass", socksProxy.password);
+
+        socksProxy = (SocksProxy) helper.parse("socks://localhost:1234/");
+        assertEquals("localhost", socksProxy.ip);
+        assertEquals(1234, socksProxy.port);
+        assertNull(socksProxy.username);
+        assertNull(socksProxy.password);
+
+        socksProxy = (SocksProxy) helper.parse("socks://login:pass@localhost:1234");
+        assertEquals("localhost", socksProxy.ip);
+        assertEquals(1234, socksProxy.port);
+        assertEquals("login", socksProxy.username);
+        assertEquals("pass", socksProxy.password);
+
+        socksProxy = (SocksProxy) helper.parse("socks://localhost:1234");
+        assertEquals("localhost", socksProxy.ip);
+        assertEquals(1234, socksProxy.port);
+        assertNull(socksProxy.username);
+        assertNull(socksProxy.password);
     }
     
     @Test

--- a/web/src/main/java/serposcope/controllers/admin/ProxyController.java
+++ b/web/src/main/java/serposcope/controllers/admin/ProxyController.java
@@ -101,11 +101,6 @@ public class ProxyController extends BaseController {
                 return Results.redirect(router.getReverseRoute(ProxyController.class, "proxies"));
             }
             
-            if(!Validator.isIPv4(split[1])){
-                flash.error(msg.get("admin.proxy.error.invalidIPv4", context, Optional.absent(), line).or(""));
-                return Results.redirect(router.getReverseRoute(ProxyController.class, "proxies"));                
-            }
-            
             proxy.setIp(split[1]);
             
             switch(split[0]){
@@ -128,6 +123,10 @@ public class ProxyController extends BaseController {
                     break;
                     
                 case "bind":
+                    if(!Validator.isIPv4(split[1])){
+                        flash.error(msg.get("admin.proxy.error.invalidIPv4", context, Optional.absent(), line).or(""));
+                        return Results.redirect(router.getReverseRoute(ProxyController.class, "proxies"));
+                    }
                     proxy.setType(Proxy.Type.BIND);
                     break;
                     


### PR DESCRIPTION
solve #196 
When using proxies in docker container, feature to using hostname for http proxy will be needed.

Ipv4 validation seems to be effective only for BIND ips configuration.
So I moved it.

How about this?