### PR TITLE
[Dockerfile] use ARG to pass the version as a build argument

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM java:8-jre
 
-ENV SERPOSCOPE_VERSION 2.7.1
+ARG SERPOSCOPE_VERSION
+
+ENV SERPOSCOPE_VERSION ${SERPOSCOPE_VERSION:-2.10.0}
 
 COPY serposcope /etc/default/serposcope
 RUN wget https://serposcope.serphacker.com/download/${SERPOSCOPE_VERSION}/serposcope_${SERPOSCOPE_VERSION}_all.deb -O /tmp/serposcope.deb


### PR DESCRIPTION
Add the ability to specify the version when building the Docker image by passing `--build-arg SERPOSCOPE_VERSION=2.10.0` to the `docker build` command instead of editing the Dockerfile everytime to update the version.